### PR TITLE
Avoid problems with circular import

### DIFF
--- a/arrayfire/array.py
+++ b/arrayfire/array.py
@@ -19,7 +19,6 @@ from .bcast import _bcast_var
 from .base import *
 from .index import *
 from .index import _Index4
-from .algorithm import sum
 
 def _create_array(buf, numdims, idims, dtype):
     out_arr = ct.c_void_p(0)
@@ -1059,3 +1058,5 @@ def display(a):
         safe_call(backend.get().af_print_array(a.arr))
     except:
         safe_call(backend.get().af_print_array(a.arr))
+
+from .algorithm import sum


### PR DESCRIPTION
My previous "fix" introduced a problem. As algorithms.py import array.py and array.py uses `sum` from algorithms.py the `from .array import *` in algorithms.py as not importing anything.
This created errors when for example doing the following:
```python
arrayfire.max(arrayfire.randu(3),0)
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-3-678a19c6fc42> in <module>()
----> 1 arrayfire.max(a,0)

/Library/Python/2.7/site-packages/arrayfire-3.1.0-py2.7.egg/arrayfire/algorithm.pyc in max(a, dim)
    112     """
    113     if dim is not None:
--> 114         return _parallel_dim(a, dim, backend.get().af_max)
    115     else:
    116         return _reduce_all(a, backend.get().af_max_all)

/Library/Python/2.7/site-packages/arrayfire-3.1.0-py2.7.egg/arrayfire/algorithm.pyc in _parallel_dim(a, dim, c_func)
     16
     17 def _parallel_dim(a, dim, c_func):
---> 18     out = Array()
     19     safe_call(c_func(ct.pointer(out.arr), a.arr, ct.c_int(dim)))
     20     return out

NameError: global name 'Array' is not defined
```
Moving the `from .algorithm import sum` to the bottom of the file should make sure that things get properly imported now.