### PR TITLE
Ensure that the types of the enums values are correct

### DIFF
--- a/arrayfire/library.py
+++ b/arrayfire/library.py
@@ -19,8 +19,15 @@ try:
     def _Enum_Type(v):
         return v
 except:
+    class _MetaEnum(type):
+        def __init__(cls, name, bases, attrs):
+            for attrname, attrvalue in attrs.iteritems():
+                if name != '_Enum' and isinstance(attrvalue, _Enum_Type):
+                    attrvalue.__class__ = cls
+                    attrs[attrname] = attrvalue
+
     class _Enum(object):
-        pass
+        __metaclass__ = _MetaEnum
 
     class _Enum_Type(object):
         def __init__(self, v):
@@ -31,7 +38,7 @@ class ERR(_Enum):
     Error values. For internal use only.
     """
 
-    NONE            =   _Enum_Type(0)
+    NONE            = _Enum_Type(0)
 
     #100-199 Errors in environment
     NO_MEM         = _Enum_Type(101)


### PR DESCRIPTION
When the enum package is not available it's necessary to change the type of the _Enum_Type attributes inside a class derived from _Enum to match the type of the containing class (e.g. set the type of NONE inside the class ERR to ERR). Otherwise the behaviour with or without the enum package would be different.

- Fixes #65