### PR TITLE
Contribute a numpy example to benchmarks.

### DIFF
--- a/examples/benchmarks/monte_carlo_pi.py
+++ b/examples/benchmarks/monte_carlo_pi.py
@@ -11,7 +11,7 @@
 
 from random import random
 from time import time
-from arrayfire import (array, randu)
+import numpy as np
 import arrayfire as af
 import sys
 
@@ -21,15 +21,20 @@ try:
 except NameError:
     frange = range   #Python3
 
-
-def calc_pi_device(samples):
-    x = randu(samples)
-    y = randu(samples)
-    return 4 * af.sum((x * x  + y * y) < 1) / samples
-
 # Having the function outside is faster than the lambda inside
 def in_circle(x, y):
     return (x*x + y*y) < 1
+
+def calc_pi_device(samples):
+    x = af.randu(samples)
+    y = af.randu(samples)
+    return 4 * af.sum(in_circle(x, y)) / samples
+
+def calc_pi_numpy(samples):
+    np.random.seed(1)
+    x = np.random.rand(samples)
+    y = np.random.rand(samples)
+    return 4 * np.sum(in_circle(x, y)) / samples
 
 def calc_pi_host(samples):
     count = sum(1 for k in frange(samples) if in_circle(random(), random()))
@@ -53,4 +58,5 @@ if __name__ == "__main__":
     af.info()
 
     bench(calc_pi_device)
+    bench(calc_pi_numpy)
     bench(calc_pi_host)

--- a/examples/benchmarks/monte_carlo_pi.py
+++ b/examples/benchmarks/monte_carlo_pi.py
@@ -11,9 +11,13 @@
 
 from random import random
 from time import time
-import numpy as np
 import arrayfire as af
 import sys
+
+try:
+    import numpy as np
+except:
+    np = None
 
 #alias range / xrange because xrange is faster than range in python2
 try:
@@ -32,8 +36,8 @@ def calc_pi_device(samples):
 
 def calc_pi_numpy(samples):
     np.random.seed(1)
-    x = np.random.rand(samples)
-    y = np.random.rand(samples)
+    x = np.random.rand(samples).astype(np.float32)
+    y = np.random.rand(samples).astype(np.float32)
     return 4 * np.sum(in_circle(x, y)) / samples
 
 def calc_pi_host(samples):
@@ -58,5 +62,6 @@ if __name__ == "__main__":
     af.info()
 
     bench(calc_pi_device)
-    bench(calc_pi_numpy)
+    if np:
+        bench(calc_pi_numpy)
     bench(calc_pi_host)


### PR DESCRIPTION
On my computer I get the following output:
```

ArrayFire v3.3.2 (CUDA, 64-bit Linux, build default)
Platform: CUDA Toolkit 7.5, Driver: 364.19
[0] GeForce GTX 960, 2040 MB, CUDA Compute 5.2
Monte carlo estimate of pi on device with 1 million samples: 3.146276
Average time taken: 0.396786 ms
Monte carlo estimate of pi on numpy with 1 million samples: 3.143600
Average time taken: 27.739305 ms
Monte carlo estimate of pi on host with 1 million samples: 3.142604
Average time taken: 311.017532 ms

```