### PR TITLE
Add numpy benchmarks to fft and blas. 

### DIFF
--- a/examples/benchmarks/bench_blas.py
+++ b/examples/benchmarks/bench_blas.py
@@ -11,7 +11,7 @@
 
 
 import sys
-from timeit import timeit
+from time import time
 import arrayfire as af
 
 try:
@@ -24,8 +24,9 @@ def calc_arrayfire(n):
     A = af.randu(n, n)
     af.sync()
 
-    def run():
-        B = af.matmul(A, A)
+    def run(iters):
+        for t in range(iters):
+            B = af.matmul(A, A)
         af.sync()
 
     return run
@@ -35,8 +36,9 @@ def calc_numpy(n):
     np.random.seed(1)
     A = np.random.rand(n, n).astype(np.float32)
 
-    def run():
-        B = np.dot(A, A)
+    def run(iters):
+        for t in range(iters):
+            B = np.dot(A, A)
 
     return run
 
@@ -46,7 +48,10 @@ def bench(calc, iters=100, upto=2048):
     print("Benchmark N x N matrix multiply on %s" % name)
 
     for n in range(128, upto + 128, 128):
-        t = timeit(calc(n), number=iters) / iters
+        run = calc(n)
+        start = time()
+        run(iters)
+        t = (time() - start) / iters
         gflops = 2.0 * (n ** 3) / (t * 1E9)
         print("Time taken for %4d x %4d: %0.4f Gflops" % (n, n, gflops))
 

--- a/examples/benchmarks/bench_blas.py
+++ b/examples/benchmarks/bench_blas.py
@@ -20,7 +20,7 @@ except:
     np = None
 
 
-def calc_device(n):
+def calc_arrayfire(n):
     A = af.randu(n, n)
     af.sync()
 
@@ -58,6 +58,6 @@ if __name__ == "__main__":
 
     af.info()
 
-    bench(calc_device)
+    bench(calc_arrayfire)
     if np:
         bench(calc_numpy, upto=512)

--- a/examples/benchmarks/bench_blas.py
+++ b/examples/benchmarks/bench_blas.py
@@ -11,16 +11,45 @@
 
 
 import sys
-from time import time
-from arrayfire import (array, randu, matmul)
+from timeit import timeit
 import arrayfire as af
 
-def bench(A, iters = 100):
-    start = time()
-    for t in range(iters):
-        B = af.matmul(A, A)
+try:
+    import numpy as np
+except:
+    np = None
+
+
+def calc_device(n):
+    A = af.randu(n, n)
     af.sync()
-    return (time() - start) / iters
+
+    def run():
+        B = af.matmul(A, A)
+        af.sync()
+
+    return run
+
+
+def calc_numpy(n):
+    np.random.seed(1)
+    A = np.random.rand(n, n).astype(np.float32)
+
+    def run():
+        B = np.dot(A, A)
+
+    return run
+
+
+def bench(calc, iters=100, upto=2048):
+    _, name = calc.__name__.split("_")
+    print("Benchmark N x N matrix multiply on %s" % name)
+
+    for n in range(128, upto + 128, 128):
+        t = timeit(calc(n), number=iters) / iters
+        gflops = 2.0 * (n ** 3) / (t * 1E9)
+        print("Time taken for %4d x %4d: %0.4f Gflops" % (n, n, gflops))
+
 
 if __name__ == "__main__":
 
@@ -28,12 +57,7 @@ if __name__ == "__main__":
         af.set_device(int(sys.argv[1]))
 
     af.info()
-    print("Benchmark N x N matrix multiply")
 
-    for n in range(128, 2048 + 128, 128):
-        A = af.randu(n, n)
-        af.sync()
-
-        t = bench(A)
-        gflops = 2.0 * (n**3) / (t * 1E9)
-        print("Time taken for %4d x %4d: %0.4f Gflops" % (n, n, gflops))
+    bench(calc_device)
+    if np:
+        bench(calc_numpy, upto=512)

--- a/examples/benchmarks/bench_fft.py
+++ b/examples/benchmarks/bench_fft.py
@@ -11,16 +11,46 @@
 
 
 import sys
-from time import time
-from arrayfire import (array, randu, matmul)
+from timeit import timeit
 import arrayfire as af
 
-def bench(A, iters = 100):
-    start = time()
-    for t in range(iters):
-        B = af.fft2(A)
+try:
+    import numpy as np
+except:
+    np = None
+
+
+def calc_device(n):
+    A = af.randu(n, n)
     af.sync()
-    return (time() - start) / iters
+
+    def run():
+        B = af.fft2(A)
+        af.sync()
+
+    return run
+
+
+def calc_numpy(n):
+    np.random.seed(1)
+    A = np.random.rand(n, n).astype(np.float32)
+
+    def run():
+        B = np.fft.fft2(A)
+
+    return run
+
+
+def bench(calc, iters=100, upto=13):
+    _, name = calc.__name__.split("_")
+    print("Benchmark N x N 2D fft on %s" % name)
+
+    for M in range(7, upto):
+        N = 1 << M
+        t = timeit(calc(N), number=iters) / iters
+        gflops = (10.0 * N * N * M) / (t * 1E9)
+        print("Time taken for %4d x %4d: %0.4f Gflops" % (N, N, gflops))
+
 
 if __name__ == "__main__":
 
@@ -28,13 +58,7 @@ if __name__ == "__main__":
         af.set_device(int(sys.argv[1]))
 
     af.info()
-    print("Benchmark N x N 2D fft")
 
-    for M in range(7, 13):
-        N = 1 << M
-        A = af.randu(N, N)
-        af.sync()
-
-        t = bench(A)
-        gflops = (10.0 * N * N * M) / (t * 1E9)
-        print("Time taken for %4d x %4d: %0.4f Gflops" % (N, N, gflops))
+    bench(calc_device)
+    if np:
+        bench(calc_numpy, upto=10)

--- a/examples/benchmarks/bench_fft.py
+++ b/examples/benchmarks/bench_fft.py
@@ -11,7 +11,7 @@
 
 
 import sys
-from timeit import timeit
+from time import time
 import arrayfire as af
 
 try:
@@ -24,8 +24,10 @@ def calc_arrayfire(n):
     A = af.randu(n, n)
     af.sync()
 
-    def run():
-        B = af.fft2(A)
+    def run(iters):
+        for t in range(iters):
+            B = af.fft2(A)
+
         af.sync()
 
     return run
@@ -35,8 +37,9 @@ def calc_numpy(n):
     np.random.seed(1)
     A = np.random.rand(n, n).astype(np.float32)
 
-    def run():
-        B = np.fft.fft2(A)
+    def run(iters):
+        for t in range(iters):
+            B = np.fft.fft2(A)
 
     return run
 
@@ -47,7 +50,10 @@ def bench(calc, iters=100, upto=13):
 
     for M in range(7, upto):
         N = 1 << M
-        t = timeit(calc(N), number=iters) / iters
+        run = calc(N)
+        start = time()
+        run(iters)
+        t = (time() - start) / iters
         gflops = (10.0 * N * N * M) / (t * 1E9)
         print("Time taken for %4d x %4d: %0.4f Gflops" % (N, N, gflops))
 

--- a/examples/benchmarks/bench_fft.py
+++ b/examples/benchmarks/bench_fft.py
@@ -20,7 +20,7 @@ except:
     np = None
 
 
-def calc_device(n):
+def calc_arrayfire(n):
     A = af.randu(n, n)
     af.sync()
 
@@ -59,6 +59,6 @@ if __name__ == "__main__":
 
     af.info()
 
-    bench(calc_device)
+    bench(calc_arrayfire)
     if np:
         bench(calc_numpy, upto=10)


### PR DESCRIPTION
Compares the following functions

 arrayfire  |  numpy |
---|---|
 af.matmul  | np.dot     |
 af.fft2         | np.fft.fft2 |


Also switch to timeit for benchmark measurements. timeit turns off the python garbage collection during measurements, so the results may be more accurate. 