### PR TITLE
Fix standalone tests module.

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+#######################################################
+# Copyright (c) 2015, ArrayFire
+# All rights reserved.
+#
+# This file is distributed under 3-clause BSD license.
+# The complete license agreement can be obtained at:
+# http://arrayfire.com/licenses/BSD-3-Clause
+########################################################

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -7,8 +7,10 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 ########################################################
 
+from __future__ import absolute_import
+
 import sys
-from simple_tests import *
+from .simple_tests import *
 
 tests = {}
 tests['simple'] = simple.tests

--- a/tests/simple_tests.py
+++ b/tests/simple_tests.py
@@ -9,7 +9,9 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 ########################################################
 
-import simple
+from __future__ import absolute_import
+
+from . import simple
 import sys
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes the standalone `tests` folder an executable module by adding the missing `__init__.py`.

Now one can copy `tests` where the `arrayfire` module was built and run `python -m tests` to execute the testsuite. This is particularly useful for CI. The remaining fixes makes the standalone execution compatible with Python 3 (only absolute imports are allowed).