### PR TITLE
erfinv and erfcinv

### DIFF
--- a/arrayfire/arith.py
+++ b/arrayfire/arith.py
@@ -817,6 +817,26 @@ def erf(a):
     """
     return _arith_unary_func(a, backend.get().af_erf)
 
+def erfinv(a):
+    """
+    Inverse error function of each element in the array.
+
+    Parameters
+    ----------
+    a : af.Array
+        Multi dimensional arrayfire array.
+
+    Returns
+    --------
+    out : af.Array
+         array containing the inverse error function of each value from `a`.
+
+    Note
+    -------
+    `a` must not be complex.
+    """
+    return _arith_unary_func(a, backend.get().af_erfinv)
+
 def erfc(a):
     """
     Complementary error function of each element in the array.
@@ -836,6 +856,26 @@ def erfc(a):
     `a` must not be complex.
     """
     return _arith_unary_func(a, backend.get().af_erfc)
+
+def erfcinv(a):
+    """
+    Complementary inverse error function of each element in the array.
+
+    Parameters
+    ----------
+    a : af.Array
+        Multi dimensional arrayfire array.
+
+    Returns
+    --------
+    out : af.Array
+         array containing the complementary inverse error function of each value from `a`.
+
+    Note
+    -------
+    `a` must not be complex.
+    """
+    return _arith_unary_func(a, backend.get().af_erfcinv)
 
 def log(a):
     """


### PR DESCRIPTION
Ref:
1. [https://www.accelereyes.com/arrayfire/c/group__array__func__erfinv.htm](https://www.accelereyes.com/arrayfire/c/group__array__func__erfinv.htm)
2. [https://www.accelereyes.com/arrayfire/c/group__array__func__erfcinv.htm](https://www.accelereyes.com/arrayfire/c/group__array__func__erfcinv.htm)
3. [Issue #731](https://github.com/arrayfire/arrayfire/issues/731)
4. [ArrayFire PR #1608 ](https://github.com/arrayfire/arrayfire/pull/1608)

I attempted to add these missing functions to ArrayFire by following the pattern that I saw with erf and erfc, but after successfully building and installing ArraryFire in a clean build directory ( 'make test' passes 100%) then modifying arrayfire-python as in this pull request, I get the following error:

```
In [1]: import arrayfire as af
In [2]: af.erfinv(af.Array([0.5]))

RuntimeError                              Traceback (most recent call last)
<ipython-input-4-dfc672d2c67e> in <module>()
----> 1 af.erfinv(af.Array([0.5]))

/usr/local/lib/python2.7/dist-packages/arrayfire-3.4.0-py2.7.egg/arrayfire/arith.pyc
in erfinv(a)
    836     `a` must not be complex.
    837     """
--> 838     return _arith_unary_func(a, backend.get().af_erfinv)
    839
    840 def erfc(a):
...

/usr/local/lib/python2.7/dist-packages/arrayfire-3.4.0-py2.7.egg/arrayfire/arith.pyc
in _arith_unary_func(a, c_func)
     47 def _arith_unary_func(a, c_func):
     48     out = Array()
---> 49     safe_call(c_func(c_pointer(out.arr), a.arr))
     50     return out
     51

/usr/local/lib/python2.7/dist-packages/arrayfire-3.4.0-py2.7.egg/arrayfire/util.pyc
in safe_call(af_error)
     77         err_len = c_dim_t(0)
     78         backend.get().af_get_last_error(c_pointer(err_str),
c_pointer(err_len))
---> 79         raise RuntimeError(to_str(err_str))
     80
     81 def get_version():

RuntimeError: Error in af_err unified::AFSymbolManager::call(const
char*, CalleeArgs ...) [with CalleeArgs = {void**, void*}]
In file src/api/unified/symbol_manager.hpp:68
Failed to load symbol: af_erfinv
```

What might I be missing?
