### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include docs *
+recursive-include examples *
+include CHANGELOG.md LICENSE README.md


### PR DESCRIPTION
In addition to the arrayfire Python module, the tarball generated with `sdist` now contains the docs, examples, changelog, readme and licensing terms. This is desirable for downstream packaging by Linux distributions, which usually source Python packages from PyPI instead of the upstream repository.