### PR TITLE
Fix lapack test on OpenCL devices

### DIFF
--- a/arrayfire/array.py
+++ b/arrayfire/array.py
@@ -1008,7 +1008,9 @@ class Array(BaseArray):
         """
         Return ~self
         """
-        return self == 0
+        out = Array()
+        safe_call(backend.get().af_not(c_pointer(out.arr), self.arr))
+        self = out
 
     def __nonzero__(self):
         return self != 0

--- a/arrayfire/array.py
+++ b/arrayfire/array.py
@@ -1011,6 +1011,7 @@ class Array(BaseArray):
         out = Array()
         safe_call(backend.get().af_not(c_pointer(out.arr), self.arr))
         self = out
+        return self
 
     def __nonzero__(self):
         return self != 0

--- a/arrayfire/data.py
+++ b/arrayfire/data.py
@@ -799,3 +799,46 @@ def replace(lhs, cond, rhs):
         safe_call(backend.get().af_replace(lhs.arr, cond.arr, rhs.arr))
     else:
         safe_call(backend.get().af_replace_scalar(lhs.arr, cond.arr, c_double_t(rhs)))
+
+def lookup(a, idx, dim=0):
+    """
+    Lookup the values of input array based on index.
+
+    Parameters
+    ----------
+
+    a : af.Array.
+       Multi dimensional array.
+
+    idx : is lookup indices
+
+    dim : optional: int. default: 0.
+       Specifies the dimension for indexing
+
+    Returns
+    -------
+
+    out : af.Array
+          An array containing values at locations specified by 'idx'
+
+    Examples
+    ---------
+
+    >>> import arrayfire as af
+    >>> a = af.randu(3, 3)
+    >>> af.display(a)
+    [3 3 1 1]
+        0.7269     0.3569     0.3341
+        0.7104     0.1437     0.0899
+        0.5201     0.4563     0.5363
+
+    >>> idx = af.array([1, 2])
+    >>> o = af.lookup()
+    [2 1 1 1]
+        0.7269     0.3569     0.3341
+        0.7104     0.1437     0.0899
+
+    """
+    out = Array()
+    safe_call(backend.get().af_lookup(c_pointer(out.arr), a.arr, idx.arr, c_int_t(dim)))
+    return out

--- a/arrayfire/data.py
+++ b/arrayfire/data.py
@@ -825,19 +825,23 @@ def lookup(a, idx, dim=0):
     ---------
 
     >>> import arrayfire as af
-    >>> a = af.randu(3, 3)
-    >>> af.display(a)
-    [3 3 1 1]
-        0.7269     0.3569     0.3341
-        0.7104     0.1437     0.0899
-        0.5201     0.4563     0.5363
+    >>> arr = af.Array([1,0,3,4,5,6], (2,3))
+    >>> af.display(arr)
+    [2 3 1 1]
+        1.0000     3.0000     5.0000
+        0.0000     4.0000     6.0000
 
-    >>> idx = af.array([1, 2])
-    >>> o = af.lookup()
+    >>> idx = af.array([0, 2])
+    >>> af.lookup(arr, idx, 1)
+    [2 2 1 1]
+        1.0000     5.0000
+        0.0000     6.0000
+
+    >>> idx = af.array([0])
+    >>> af.lookup(arr, idx, 0)
     [2 1 1 1]
-        0.7269     0.3569     0.3341
-        0.7104     0.1437     0.0899
-
+        0.0000
+        2.0000
     """
     out = Array()
     safe_call(backend.get().af_lookup(c_pointer(out.arr), a.arr, idx.arr, c_int_t(dim)))

--- a/arrayfire/tests/simple/lapack.py
+++ b/arrayfire/tests/simple/lapack.py
@@ -39,7 +39,7 @@ def simple_lapack(verbose=False):
     display_func(a)
 
     a = af.randu(5, 5)
-    a = af.matmulTN(a, a) + 10 * af.identity(5,5)
+    a = af.matmulTN(a, a.copy()) + 10 * af.identity(5,5)
 
     R,info = af.cholesky(a)
     display_func(R)


### PR DESCRIPTION
In my desktop, the default device is an Intel/OpenCL stuff. The lapack test fails on that with the following error:

```
ERROR:root:Traceback (most recent call last):
  File "C:\git\arrayfire-python\arrayfire\tests\simple\_util.py", line 32, in run
    test(verbose)
  File "C:\git\arrayfire-python\arrayfire\tests\simple\lapack.py", line 42, in simple_lapack
    a = af.matmulTN(a, a) + 10 * af.identity(5,5)
  File "C:\git\arrayfire-python\arrayfire\blas.py", line 88, in matmulTN
    MATPROP.TRANS.value, MATPROP.NONE.value))
  File "C:\git\arrayfire-python\arrayfire\util.py", line 79, in safe_call
    raise RuntimeError(to_str(err_str))
RuntimeError: In function class std::shared_ptr<float> __cdecl opencl::Array<float>::getMappedPtr(void) const
In file src\backend\opencl\Array.hpp:260
OpenCL Error (-59): Invalid Operation when calling clEnqueueMapBuffer
```

It is obvious, because on lapack.py line 42 I found:

```python
a = af.matmulTN(a, a) + 10 * af.identity(5,5)
```

Which leads to double OpenCL mapping of the same resource. I've fixed that line with an explicit copy, but I believe this situation should handled at core ArrayFire side. Maybe with a better error reporting, or with an implicit copy when this double map scenario happens. What do you think?