### PR TITLE
Fix lapack test on OpenCL devices

### DIFF
--- a/arrayfire/tests/simple/lapack.py
+++ b/arrayfire/tests/simple/lapack.py
@@ -39,7 +39,7 @@ def simple_lapack(verbose=False):
     display_func(a)
 
     a = af.randu(5, 5)
-    a = af.matmulTN(a, a) + 10 * af.identity(5,5)
+    a = af.matmulTN(a, a.copy()) + 10 * af.identity(5,5)
 
     R,info = af.cholesky(a)
     display_func(R)


### PR DESCRIPTION
In my desktop, the default device is an Intel/OpenCL stuff. The lapack test fails on that with the following error:

```
ERROR:root:Traceback (most recent call last):
  File "C:\git\arrayfire-python\arrayfire\tests\simple\_util.py", line 32, in run
    test(verbose)
  File "C:\git\arrayfire-python\arrayfire\tests\simple\lapack.py", line 42, in simple_lapack
    a = af.matmulTN(a, a) + 10 * af.identity(5,5)
  File "C:\git\arrayfire-python\arrayfire\blas.py", line 88, in matmulTN
    MATPROP.TRANS.value, MATPROP.NONE.value))
  File "C:\git\arrayfire-python\arrayfire\util.py", line 79, in safe_call
    raise RuntimeError(to_str(err_str))
RuntimeError: In function class std::shared_ptr<float> __cdecl opencl::Array<float>::getMappedPtr(void) const
In file src\backend\opencl\Array.hpp:260
OpenCL Error (-59): Invalid Operation when calling clEnqueueMapBuffer
```

It is obvious, because on lapack.py line 42 I found:

```python
a = af.matmulTN(a, a) + 10 * af.identity(5,5)
```

Which leads to double OpenCL mapping of the same resource. I've fixed that line with an explicit copy, but I believe this situation should handled at core ArrayFire side. Maybe with a better error reporting, or with an implicit copy when this double map scenario happens. What do you think?