### PR TITLE
IDE compatible and not leaking __repr__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IDE
+.idea
+.vscode

--- a/arrayfire/array.py
+++ b/arrayfire/array.py
@@ -72,10 +72,10 @@ def _in_display_dims_limit(dims):
         return False
     if _display_dims_limit is not None:
         limit_len = len(_display_dims_limit)
-        len = len(dims)
-        if len > limit_len:
+        dim_len = len(dims)
+        if dim_len > limit_len:
             return False
-        for i in range(len):
+        for i in range(dim_len):
             if dims[i] > _display_dims_limit[i]:
                 return False
     return True

--- a/arrayfire/array.py
+++ b/arrayfire/array.py
@@ -1185,9 +1185,9 @@ class Array(BaseArray):
         ct_array, shape = self.to_ctype(row_major, True)
         return _ctype_to_lists(ct_array, len(shape) - 1, shape)
 
-    def __repr__(self):
+    def to_string(self):
         """
-        Displays the meta data and contents of  the arrayfire array.
+        Converts the arrayfire array to string showing its meta data and contents.
 
         Note
         ----
@@ -1195,10 +1195,25 @@ class Array(BaseArray):
         """
 
         arr_str = c_char_ptr_t(0)
-        safe_call(backend.get().af_array_to_string(c_pointer(arr_str), "", self.arr, 4, True))
+        be = backend.get()
+        safe_call(be.af_array_to_string(c_pointer(arr_str), "", self.arr, 4, True))
+        py_str = to_str(arr_str)
+        safe_call(be.af_free_host(arr_str))
 
-        return 'arrayfire.Array()\nType: %s' % \
-            (to_typename[self.type()]) + to_str(arr_str)
+        return 'arrayfire.Array()\nType: {}\nDims: {}\nData: {}' \
+            .format(to_typename[self.type()], str(self.dims()), py_str)
+
+    def __repr__(self):
+        """
+        Displays the meta data of the arrayfire array.
+
+        Note
+        ----
+        You can use af.display(a, pres) to display the contents of the array.
+        """
+
+        return 'arrayfire.Array()\nType: {}\nDims: {}' \
+            .format(to_typename[self.type()], str(self.dims()))
 
     def __array__(self):
         """

--- a/arrayfire/array.py
+++ b/arrayfire/array.py
@@ -1253,7 +1253,7 @@ class Array(BaseArray):
         """
 
         if not _in_display_dims_limit(self.dims()):
-            return self.__repr__();
+            return self.__repr__()
 
         arr_str = c_char_ptr_t(0)
         be = backend.get()


### PR DESCRIPTION
Changes:

* `__repr__` made IDE friendly
* `to_string()` added to have a method for getting the full string representation
* memory leak after calling `af_array_to_string` fixed

I haven't make the full representation method as `__str__` because PyCharm invokes that automatically even it uses `__repr__` for display.