### PR TITLE
fix of np_to_af_array

### DIFF
--- a/arrayfire/interop.py
+++ b/arrayfire/interop.py
@@ -63,16 +63,13 @@ try:
             if np_arr.ndim == 1:
                 return Array(in_ptr, in_shape, in_dtype)
             elif np_arr.ndim == 2:
-                shape = (in_shape[1], in_shape[0])
-                res = Array(in_ptr, shape, in_dtype)
+                res = Array(in_ptr, in_shape, in_dtype)
                 return reorder(res, 1, 0)
             elif np_arr.ndim == 3:
-                shape = (in_shape[2], in_shape[1], in_shape[0])
-                res = Array(in_ptr, shape, in_dtype)
+                res = Array(in_ptr, in_shape, in_dtype)
                 return reorder(res, 2, 1, 0)
             elif np_arr.ndim == 4:
-                shape = (in_shape[3], in_shape[2], in_shape[1], in_shape[0])
-                res = Array(in_ptr, shape, in_dtype)
+                res = Array(in_ptr, in_shape, in_dtype)
                 return reorder(res, 3, 2, 1, 0)
             else:
                 raise RuntimeError("Unsupported ndim")


### PR DESCRIPTION
If I have a test:

```python
np_arr = np.full((2, 3, 4), 1, dtype='int32')
np_arr[1, :, 3] = 2
np_arr[1, 2, 3] = 4
af_arr = af.np_to_af_array(np_arr)
self.assertEqual(af_arr.shape[0], 4)
self.assertEqual(af_arr.shape[1], 3)
self.assertEqual(af_arr.shape[2], 2)
self.assertEqual(af_arr[3, 1, 1], 2)
self.assertEqual(af_arr[3, 2, 1], 4)
```

That will fail, because ArrayFire's conversion incorrectly handles the `C_CONTIGUOUS` case in interop.py. Dimesnions should not be reversed before the reorder.

Applying the PR the above test case will pass.