### PR TITLE
Add measured locations as parameters for approx1 and approx2

### DIFF
--- a/arrayfire/signal.py
+++ b/arrayfire/signal.py
@@ -94,6 +94,40 @@ def approx2(signal, pos0, pos1, method=INTERP.LINEAR, off_grid=0.0):
                                        pos0.arr, pos1.arr, method.value, c_float_t(off_grid)))
     return output
 
+def interp1d(x_interpolated, x_input, signal_input, method=INTERP.LINEAR, off_grid=0.0):
+    """
+    One-dimensional linear interpolation.Interpolation is performed along axis 0.
+
+    Parameters
+    ----------
+
+    x : af.Array
+        The x-coordinates of the interpolated values. The interpolation function
+        is queried at these set of points.
+
+    x : af.Array
+        The x-coordinates of the data points
+
+    signal_input: af.Array
+                  Input signal array(uniform data)
+
+    method: optional: af.INTERP. default: af.INTERP.LINEAR.
+            Interpolation method.
+
+    off_grid: optional: scalar. default: 0.0.
+              The value used for positions outside the range.
+
+    Returns
+    -------
+
+    output: af.Array
+            Values calculated at interpolation points.
+    """
+    dx   = sum(x_input[1, 0, 0, 0] - x_input[0, 0, 0, 0])
+    pos0 = (x_interpolated - sum(x_input[0, 0, 0, 0]))/dx
+
+    return approx1(signal_input, pos0, method, off_grid)
+
 def fft(signal, dim0 = None , scale = None):
     """
     Fast Fourier Transform: 1D

--- a/arrayfire/signal.py
+++ b/arrayfire/signal.py
@@ -96,20 +96,21 @@ def approx2(signal, pos0, pos1, method=INTERP.LINEAR, off_grid=0.0):
 
 def interp1d(x_interpolated, x_input, signal_input, method=INTERP.LINEAR, off_grid=0.0):
     """
-    One-dimensional linear interpolation.Interpolation is performed along axis 0.
+    One-dimensional linear interpolation.Interpolation is performed along axis 0
+    of the input array.
 
     Parameters
     ----------
 
-    x : af.Array
-        The x-coordinates of the interpolated values. The interpolation function
-        is queried at these set of points.
+    x_interpolated : af.Array
+                     The x-coordinates of the interpolation points. The interpolation 
+                     function is queried at these set of points.
 
     x : af.Array
-        The x-coordinates of the data points
+        The x-coordinates of the input data points
 
     signal_input: af.Array
-                  Input signal array(uniform data)
+                  Input signal array (signal = f(x))
 
     method: optional: af.INTERP. default: af.INTERP.LINEAR.
             Interpolation method.
@@ -127,6 +128,56 @@ def interp1d(x_interpolated, x_input, signal_input, method=INTERP.LINEAR, off_gr
     pos0 = (x_interpolated - sum(x_input[0, 0, 0, 0]))/dx
 
     return approx1(signal_input, pos0, method, off_grid)
+
+
+def interp2d(x_interpolated, x_input, y_interpolated, y_input, 
+             signal_input, method=INTERP.LINEAR, off_grid=0.0
+            ):
+    """
+    Two-dimensional linear interpolation.Interpolation is performed along axes 0 and 1
+    of the input array.
+
+    Parameters
+    ----------
+
+    x_interpolated : af.Array
+                     The x-coordinates of the interpolation points. The interpolation 
+                     function is queried at these set of points.
+
+    x : af.Array
+        The x-coordinates of the input data points. The convention followed is that
+        the x-coordinates vary along axis 0
+
+    y_interpolated : af.Array
+                     The y-coordinates of the interpolation points. The interpolation 
+                     function is queried at these set of points.
+
+    y : af.Array
+        The y-coordinates of the input data points. The convention followed is that
+        the y-coordinates vary along axis 1
+
+    signal_input: af.Array
+                  Input signal array (signal = f(x, y))
+
+    method: optional: af.INTERP. default: af.INTERP.LINEAR.
+            Interpolation method.
+
+    off_grid: optional: scalar. default: 0.0.
+              The value used for positions outside the range.
+
+    Returns
+    -------
+
+    output: af.Array
+            Values calculated at interpolation points.
+    """
+    dx = sum(x_input[1, 0, 0, 0] - x_input[0, 0, 0, 0])
+    dy = sum(y_input[0, 1, 0, 0] - y_input[0, 0, 0, 0])
+
+    pos0 = (x_interpolated - sum(x_input[0, 0, 0, 0]))/dx
+    pos1 = (y_interpolated - sum(y_input[0, 0, 0, 0]))/dy
+
+    return approx2(signal_input, pos0, pos1, method, off_grid)
 
 def fft(signal, dim0 = None , scale = None):
     """

--- a/arrayfire/signal.py
+++ b/arrayfire/signal.py
@@ -27,7 +27,7 @@ def _scale_pos_axis1(y_curr, y_orig):
     dy = y_orig[0, 1, 0, 0] - y0
     return((y_curr - y0) / dy)
 
-def approx1(x_interpolated, x_input, signal_input, method=INTERP.LINEAR, off_grid=0.0):
+def approx1(signal, x_interpolated, method=INTERP.LINEAR, off_grid=0.0, x_input = None):
     """
     Interpolate along a single dimension.Interpolation is performed along axis 0
     of the input array.
@@ -35,16 +35,12 @@ def approx1(x_interpolated, x_input, signal_input, method=INTERP.LINEAR, off_gri
     Parameters
     ----------
 
+    signal: af.Array
+            Input signal array (signal = f(x))
+
     x_interpolated : af.Array
                      The x-coordinates of the interpolation points. The interpolation 
                      function is queried at these set of points.
-
-    x_input : af.Array
-              The x-coordinates of the input data points
-
-    signal_input: af.Array
-                  Input signal array (signal = f(x))
-
 
     method: optional: af.INTERP. default: af.INTERP.LINEAR.
             Interpolation method.
@@ -52,20 +48,36 @@ def approx1(x_interpolated, x_input, signal_input, method=INTERP.LINEAR, off_gri
     off_grid: optional: scalar. default: 0.0.
             The value used for positions outside the range.
 
+    x_input : af.Array
+              The x-coordinates of the input data points
+
     Returns
     -------
 
     output: af.Array
             Values calculated at interpolation points.
+
+
+    Note
+    -----
+    This holds applicable when x_input isn't provided:
+    The initial measurements are assumed to have taken place at equal steps between [0, N - 1],
+    where N is the length of the first dimension of `signal`.
     """
+
     output = Array()
-    pos0   = _scale_pos_axis0(x_interpolated, x_input)
-    safe_call(backend.get().af_approx1(c_pointer(output.arr), signal_input.arr, pos0.arr,
+
+    if(x_input is not None):
+        pos0 = _scale_pos_axis0(x_interpolated, x_input)
+    else:
+        pos0 = x_interpolated
+
+    safe_call(backend.get().af_approx1(c_pointer(output.arr), signal.arr, pos0.arr,
                                        method.value, c_float_t(off_grid)))
     return output
 
-def approx2(x_interpolated, x_input, y_interpolated, y_input, signal_input, 
-            method=INTERP.LINEAR, off_grid=0.0
+def approx2(signal, x_interpolated, y_interpolated,
+            method=INTERP.LINEAR, off_grid=0.0, x_input = None, y_input = None 
            ):
     """
     Interpolate along a two dimension.Interpolation is performed along axes 0 and 1
@@ -74,24 +86,17 @@ def approx2(x_interpolated, x_input, y_interpolated, y_input, signal_input,
     Parameters
     ----------
 
+    signal: af.Array
+            Input signal array (signal = f(x, y))
+
     x_interpolated : af.Array
                      The x-coordinates of the interpolation points. The interpolation 
                      function is queried at these set of points.
 
-    x_input : af.Array
-              The x-coordinates of the input data points. The convention followed is that
-              the x-coordinates vary along axis 0
 
     y_interpolated : af.Array
                      The y-coordinates of the interpolation points. The interpolation 
                      function is queried at these set of points.
-
-    y_input : af.Array
-              The y-coordinates of the input data points. The convention followed is that
-              the y-coordinates vary along axis 1
-
-    signal_input: af.Array
-                  Input signal array (signal = f(x, y))
 
     method: optional: af.INTERP. default: af.INTERP.LINEAR.
             Interpolation method.
@@ -99,17 +104,42 @@ def approx2(x_interpolated, x_input, y_interpolated, y_input, signal_input,
     off_grid: optional: scalar. default: 0.0.
             The value used for positions outside the range.
 
+    x_input : af.Array
+              The x-coordinates of the input data points. The convention followed is that
+              the x-coordinates vary along axis 0
+
+    y_input : af.Array
+              The y-coordinates of the input data points. The convention followed is that
+              the y-coordinates vary along axis 1
+
     Returns
     -------
 
     output: af.Array
             Values calculated at interpolation points.
 
+    Note
+    -----
+    This holds applicable when x_input/y_input isn't provided:
+
+    The initial measurements are assumed to have taken place at equal steps between [(0,0) - [M - 1, N - 1]]
+    where M is the length of the first dimension of `signal`,
+    and N is the length of the second dimension of `signal`.
     """
+
     output = Array()
-    pos0   = _scale_pos_axis0(x_interpolated, x_input)
-    pos1   = _scale_pos_axis1(y_interpolated, y_input)
-    safe_call(backend.get().af_approx2(c_pointer(output.arr), signal_input.arr,
+    
+    if(x_input is not None):
+        pos0 = _scale_pos_axis0(x_interpolated, x_input)
+    else:
+        pos0 = x_interpolated
+
+    if(y_input is not None):
+        pos1 = _scale_pos_axis1(y_interpolated, y_input)
+    else:
+        pos1 = y_interpolated
+
+    safe_call(backend.get().af_approx2(c_pointer(output.arr), signal.arr,
                                        pos0.arr, pos1.arr, method.value, c_float_t(off_grid)))
     return output
 

--- a/arrayfire/signal.py
+++ b/arrayfire/signal.py
@@ -27,7 +27,7 @@ def _scale_pos_axis1(y_curr, y_orig):
     dy = y_orig[0, 1, 0, 0] - y0
     return((y_curr - y0) / dy)
 
-def approx1(signal, x_interpolated, method=INTERP.LINEAR, off_grid=0.0, x_input = None):
+def approx1(signal, x, method=INTERP.LINEAR, off_grid=0.0, xp = None):
     """
     Interpolate along a single dimension.Interpolation is performed along axis 0
     of the input array.
@@ -38,9 +38,9 @@ def approx1(signal, x_interpolated, method=INTERP.LINEAR, off_grid=0.0, x_input 
     signal: af.Array
             Input signal array (signal = f(x))
 
-    x_interpolated : af.Array
-                     The x-coordinates of the interpolation points. The interpolation 
-                     function is queried at these set of points.
+    x: af.Array
+       The x-coordinates of the interpolation points. The interpolation 
+       function is queried at these set of points.
 
     method: optional: af.INTERP. default: af.INTERP.LINEAR.
             Interpolation method.
@@ -48,8 +48,8 @@ def approx1(signal, x_interpolated, method=INTERP.LINEAR, off_grid=0.0, x_input 
     off_grid: optional: scalar. default: 0.0.
             The value used for positions outside the range.
 
-    x_input : af.Array
-              The x-coordinates of the input data points
+    xp : af.Array
+         The x-coordinates of the input data points
 
     Returns
     -------
@@ -67,17 +67,17 @@ def approx1(signal, x_interpolated, method=INTERP.LINEAR, off_grid=0.0, x_input 
 
     output = Array()
 
-    if(x_input is not None):
-        pos0 = _scale_pos_axis0(x_interpolated, x_input)
+    if(xp is not None):
+        pos0 = _scale_pos_axis0(x, xp)
     else:
-        pos0 = x_interpolated
+        pos0 = x
 
     safe_call(backend.get().af_approx1(c_pointer(output.arr), signal.arr, pos0.arr,
                                        method.value, c_float_t(off_grid)))
     return output
 
-def approx2(signal, x_interpolated, y_interpolated,
-            method=INTERP.LINEAR, off_grid=0.0, x_input = None, y_input = None 
+def approx2(signal, x, y,
+            method=INTERP.LINEAR, off_grid=0.0, xp = None, yp = None 
            ):
     """
     Interpolate along a two dimension.Interpolation is performed along axes 0 and 1
@@ -89,14 +89,14 @@ def approx2(signal, x_interpolated, y_interpolated,
     signal: af.Array
             Input signal array (signal = f(x, y))
 
-    x_interpolated : af.Array
-                     The x-coordinates of the interpolation points. The interpolation 
-                     function is queried at these set of points.
+    x : af.Array
+        The x-coordinates of the interpolation points. The interpolation 
+        function is queried at these set of points.
 
 
-    y_interpolated : af.Array
-                     The y-coordinates of the interpolation points. The interpolation 
-                     function is queried at these set of points.
+    y : af.Array
+        The y-coordinates of the interpolation points. The interpolation 
+        function is queried at these set of points.
 
     method: optional: af.INTERP. default: af.INTERP.LINEAR.
             Interpolation method.
@@ -104,13 +104,13 @@ def approx2(signal, x_interpolated, y_interpolated,
     off_grid: optional: scalar. default: 0.0.
             The value used for positions outside the range.
 
-    x_input : af.Array
-              The x-coordinates of the input data points. The convention followed is that
-              the x-coordinates vary along axis 0
+    xp : af.Array
+         The x-coordinates of the input data points. The convention followed is that
+         the x-coordinates vary along axis 0
 
-    y_input : af.Array
-              The y-coordinates of the input data points. The convention followed is that
-              the y-coordinates vary along axis 1
+    yp : af.Array
+         The y-coordinates of the input data points. The convention followed is that
+         the y-coordinates vary along axis 1
 
     Returns
     -------
@@ -129,15 +129,15 @@ def approx2(signal, x_interpolated, y_interpolated,
 
     output = Array()
     
-    if(x_input is not None):
-        pos0 = _scale_pos_axis0(x_interpolated, x_input)
+    if(xp is not None):
+        pos0 = _scale_pos_axis0(x, xp)
     else:
-        pos0 = x_interpolated
+        pos0 = x
 
-    if(y_input is not None):
-        pos1 = _scale_pos_axis1(y_interpolated, y_input)
+    if(yp is not None):
+        pos1 = _scale_pos_axis1(y, yp)
     else:
-        pos1 = y_interpolated
+        pos1 = y
 
     safe_call(backend.get().af_approx2(c_pointer(output.arr), signal.arr,
                                        pos0.arr, pos1.arr, method.value, c_float_t(off_grid)))

--- a/arrayfire/tests/simple/signal.py
+++ b/arrayfire/tests/simple/signal.py
@@ -18,7 +18,7 @@ def simple_signal(verbose=False):
     signal = af.randu(10)
     x_new  = af.randu(10)
     x_orig = af.randu(10)
-    display_func(af.approx1(x_new, x_orig, signal))
+    display_func(af.approx1(signal, x_new, x_input = x_orig))
 
     signal = af.randu(3, 3)
     x_new  = af.randu(3, 3)
@@ -26,7 +26,7 @@ def simple_signal(verbose=False):
     y_new  = af.randu(3, 3)
     y_orig = af.randu(3, 3)
 
-    display_func(af.approx2(x_new, x_orig, y_new, y_orig, signal))
+    display_func(af.approx2(signal, x_new, y_new, x_input = x_orig, y_input = y_orig))
 
     a = af.randu(8, 1)
     display_func(a)

--- a/arrayfire/tests/simple/signal.py
+++ b/arrayfire/tests/simple/signal.py
@@ -15,15 +15,18 @@ def simple_signal(verbose=False):
     display_func = _util.display_func(verbose)
     print_func   = _util.print_func(verbose)
 
-    a = af.randu(10, 1)
-    pos0 = af.randu(10) * 10
-    display_func(af.approx1(a, pos0))
+    signal = af.randu(10)
+    x_new  = af.randu(10)
+    x_orig = af.randu(10)
+    display_func(af.approx1(x_new, x_orig, signal))
 
-    a = af.randu(3, 3)
-    pos0 = af.randu(3, 3) * 10
-    pos1 = af.randu(3, 3) * 10
+    signal = af.randu(3, 3)
+    x_new  = af.randu(3, 3)
+    x_orig = af.randu(3, 3)
+    y_new  = af.randu(3, 3)
+    y_orig = af.randu(3, 3)
 
-    display_func(af.approx2(a, pos0, pos1))
+    display_func(af.approx2(x_new, x_orig, y_new, y_orig, signal))
 
     a = af.randu(8, 1)
     display_func(a)

--- a/arrayfire/tests/simple/signal.py
+++ b/arrayfire/tests/simple/signal.py
@@ -18,7 +18,7 @@ def simple_signal(verbose=False):
     signal = af.randu(10)
     x_new  = af.randu(10)
     x_orig = af.randu(10)
-    display_func(af.approx1(signal, x_new, x_input = x_orig))
+    display_func(af.approx1(signal, x_new, xp = x_orig))
 
     signal = af.randu(3, 3)
     x_new  = af.randu(3, 3)
@@ -26,7 +26,7 @@ def simple_signal(verbose=False):
     y_new  = af.randu(3, 3)
     y_orig = af.randu(3, 3)
 
-    display_func(af.approx2(signal, x_new, y_new, x_input = x_orig, y_input = y_orig))
+    display_func(af.approx2(signal, x_new, y_new, xp = x_orig, yp = y_orig))
 
     a = af.randu(8, 1)
     display_func(a)


### PR DESCRIPTION
I've implemented an `interp1d` and `interp2d` function similar to the one found in `scipy`. Rather than having the user manually transform the input points from [0, N-1] when using `approx1` and `approx2`, this function takes care of the transformation by taking the input data points in addition to the interpolation points.

However, there is one issue: I'm using `sum` to get a scalar value:
```
dx   = sum(x_input[1, 0, 0, 0] - x_input[0, 0, 0, 0])
pos0 = (x_interpolated - sum(x_input[0, 0, 0, 0]))/dx
```
Do you recommend using something else?