### PR TITLE
vision.py fixes

### DIFF
--- a/arrayfire/features.py
+++ b/arrayfire/features.py
@@ -32,6 +32,14 @@ class Features(object):
             assert(isinstance(num, numbers.Number))
             safe_call(backend.get().af_create_features(c_pointer(self.feat), c_dim_t(num)))
 
+    def __del__(self):
+        """
+        Release features' memory
+        """
+        if self.feat:
+            backend.get().af_release_features(self.feat)
+            self.feat = None
+
     def num_features(self):
         """
         Returns the number of features detected.

--- a/arrayfire/vision.py
+++ b/arrayfire/vision.py
@@ -391,9 +391,11 @@ def gloh(image, num_layers=3, contrast_threshold=0.04, edge_threshold=10.0, init
 
     feat = Features()
     desc = Array()
-    safe_call(af_gloh(c_pointer(feat), c_pointer(desc),
-                      image.arr, num_layers, contrast_threshold, edge_threshold,
-                      initial_sigma, double_input, intensity_scale, feature_ratio))
+    safe_call(backend.get().af_gloh(c_pointer(feat.feat), c_pointer(desc.arr),
+                      image.arr, num_layers, c_float_t(contrast_threshold),
+                      c_float_t(edge_threshold), c_float_t(initial_sigma),
+                      double_input, c_float_t(intensity_scale), 
+                      c_float_t(feature_ratio)))
 
     return (feat, desc)
 

--- a/arrayfire/vision.py
+++ b/arrayfire/vision.py
@@ -131,7 +131,7 @@ def orb(image, threshold=20.0, max_features=400, scale = 1.5, num_levels = 4, bl
     """
     feat = Features()
     desc = Array()
-    safe_call(backend.get().af_orb(c_pointer(feat.feat), c_pointer(desc.arr),
+    safe_call(backend.get().af_orb(c_pointer(feat.feat), c_pointer(desc.arr), image.arr,
                                    c_float_t(threshold), c_uint_t(max_features),
                                    c_float_t(scale), c_uint_t(num_levels), blur_image))
     return feat, desc

--- a/arrayfire/vision.py
+++ b/arrayfire/vision.py
@@ -345,9 +345,9 @@ def sift(image, num_layers=3, contrast_threshold=0.04, edge_threshold=10.0, init
 
     feat = Features()
     desc = Array()
-    safe_call(af_sift(c_pointer(feat), c_pointer(desc),
-                      image.arr, num_layers, contrast_threshold, edge_threshold,
-                      initial_sigma, double_input, intensity_scale, feature_ratio))
+    safe_call(backend.get().af_sift(c_pointer(feat.feat), c_pointer(desc.arr),
+                      image.arr, num_layers, c_float_t(contrast_threshold), c_float_t(edge_threshold),
+                      c_float_t(initial_sigma), double_input, c_float_t(intensity_scale), c_float_t(feature_ratio)))
 
     return (feat, desc)
 


### PR DESCRIPTION
orb and gloh calls were broken.

the features c++ destructor wasn't called and needed to be called explicitly in order to release its memory. I've added a __del__ method to features which calls af_release_features