### PR TITLE
BF: check AF library paths for pkg vs source install

### DIFF
--- a/arrayfire/library.py
+++ b/arrayfire/library.py
@@ -496,7 +496,10 @@ def _setup():
         post = '.' + _VER_MAJOR_PLACEHOLDER + '.dylib'
 
         if AF_SEARCH_PATH is None:
-            AF_SEARCH_PATH='/usr/local/'
+            if os.path.exists('/opt/arrayfire'):
+                AF_SEARCH_PATH = '/opt/arrayfire/'
+            else:
+                AF_SEARCH_PATH = '/usr/local/'
 
         if CUDA_PATH is None:
             CUDA_PATH='/usr/local/cuda/'


### PR DESCRIPTION
This fixes the specific path problem gh-217. I can import arrayfire and tests run. I am not having positive results with benchmarks (e.g. bench_cg.py). Something breaks down in ```calc_arrayfire()``` doing matrix solutions on the same arrays over a few iterations. Memory leak? Anyway that's another issue.