### PR TITLE
failing af_where with b8 datatype [WIP]

### DIFF
--- a/arrayfire/algorithm.py
+++ b/arrayfire/algorithm.py
@@ -569,6 +569,8 @@ def where(a):
          Linear indices for non zero elements.
     """
     out = Array()
+    if(a.dtype() == Dtype.b8): #TODO: fixme, fails on cuda, works in af_where
+        a = a.as_type(Dtype.u8)
     safe_call(backend.get().af_where(c_pointer(out.arr), a.arr))
     return out
 


### PR DESCRIPTION
af_where will throw a LLVM out of memory error when passing in a Array.arr with b8 data type on the cuda backend.
PR currently holds temporary workaround.

TODO: figure out root cause. af_where works for all types and backends in arrayfire core lib. Only cuda is failing in arrayfire-python
