### PR TITLE
Approx{1,2}_{v2,uniform}, af_gemm

### DIFF
--- a/arrayfire/library.py
+++ b/arrayfire/library.py
@@ -31,6 +31,13 @@ c_pointer     = ct.pointer
 c_void_ptr_t  = ct.c_void_p
 c_char_ptr_t  = ct.c_char_p
 c_size_t      = ct.c_size_t
+c_cast        = ct.cast
+
+class af_cfloat_t(ct.Structure):
+    _fields_ = [("real", ct.c_float), ("imag", ct.c_float)]
+
+class af_cdouble_t(ct.Structure):
+    _fields_ = [("real", ct.c_double), ("imag", ct.c_double)]
 
 
 AF_VER_MAJOR = '3'


### PR DESCRIPTION
This PR adds approx functions from upstream 3.7. Writing to existing array is supported by the trailing `output=` kargs.

This PR also adds support for af_gemm. Adding a af_c{float,double}_t ctypes class was necessary as complex types aren't natively supported by ctypes (afaik). 

TODO: Not sure how to best implement fp16 type