### PR TITLE
change setup.py to optionally build binaries in source distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,14 @@ include(FetchContent)
 
 set(CMAKE_MODULE_PATH_OLD ${CMAKE_MODULE_PATH})
 set(CMAKE_MODULE_PATH "")
+set(NO_SONAME)
 
 FetchContent_Declare(
     arrayfire
     GIT_REPOSITORY https://github.com/arrayfire/arrayfire.git
-    GIT_TAG v3.8.rc
+    GIT_TAG v3.8
 )
 FetchContent_MakeAvailable(arrayfire)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_OLD})
-
 
 set(ignoreWarning "${SKBUILD}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.11.0)
+project(arrayfire-python)
+find_package(PythonExtensions REQUIRED)
+include(FetchContent)
+
+set(CMAKE_MODULE_PATH_OLD ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "")
+
+FetchContent_Declare(
+    arrayfire
+    GIT_REPOSITORY https://github.com/arrayfire/arrayfire.git
+    GIT_TAG v3.8.rc
+)
+FetchContent_MakeAvailable(arrayfire)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_OLD})
+
+
+set(ignoreWarning "${SKBUILD}")

--- a/README.md
+++ b/README.md
@@ -25,21 +25,18 @@ def calc_pi_device(samples):
 
 Choosing a particular backend can be done using `af.set_backend(name)`  where name is either "_cuda_", "_opencl_", or "_cpu_". The default device is chosen in the same order of preference.
 
-## Requirements
-
-You will need to have the ArrayFire C/C++ library on your machine. You can get it from the following sources:
+## Getting started
+ArrayFire can be installed from a variety of sources. [Pre-built wheels](https://repo.arrayfire.com/python/wheels/3.8.0/) are available for a number of systems and toolkits. Wheels for some systems are available on PyPI. Unsupported systems will require separate installation of the ArrayFire C/C++ libraries and only the python wrapper will be installed in that case. 
+You can get the ArrayFire C/C++ library from the following sources:
 
 - [Download and install binaries](https://arrayfire.com/download)
 - [Build and install from source](https://github.com/arrayfire/arrayfire)
-- [Pre-built wheel distributions](https://repo.arrayfire.com/python/wheels/3.8.0/)
 
-## Getting started
 
 **Install the last stable version:**  
 ```
 pip install arrayfire
 ```
-Wheels for some systems are available on PyPI. Unsupported systems will require separate installation of the ArrayFire C/C++ libraries and only the python wrapper will be installed in that case.
 
 **Install a pre-built wheel for a specific CUDA toolkit version:**
 ```

--- a/README.md
+++ b/README.md
@@ -27,28 +27,30 @@ Choosing a particular backend can be done using `af.set_backend(name)`  where na
 
 ## Requirements
 
-Currently, this project is tested only on Linux and OSX. You also need to have the ArrayFire C/C++ library installed on your machine. You can get it from the following sources.
+You will need to have the ArrayFire C/C++ library on your machine. You can get it from the following sources:
 
 - [Download and install binaries](https://arrayfire.com/download)
 - [Build and install from source](https://github.com/arrayfire/arrayfire)
-
-Please check the following links for dependencies.
-
-- [Linux dependencies](http://www.arrayfire.com/docs/using_on_linux.htm)
-- [OSX dependencies](http://www.arrayfire.com/docs/using_on_osx.htm)
+- [Pre-built wheel distributions](https://repo.arrayfire.com/python/wheels/3.8.0/)
 
 ## Getting started
 
-**Install the last stable version:**
-
+**Install the last stable version:**  
 ```
 pip install arrayfire
 ```
+Wheels for some systems are available on PyPI. Unsupported systems will require separate installation of the ArrayFire C/C++ libraries and only the python wrapper will be installed in that case.
 
-**Install the development version:**
+**Install a pre-built wheel for a specific CUDA toolkit version:**
+```
+pip install arrayfire==3.8.0+cu112 -f https://repo.arrayfire.com/python/wheels/3.8.0/
+# Replace the +cu112 local version with the desired toolkit
+```
+
+**Install the development source distribution:**
 
 ```
-pip install git+git://github.com/arrayfire/arrayfire-python.git@devel
+pip install git+git://github.com/arrayfire/arrayfire-python.git@master
 ```
 
 **Installing offline:**
@@ -57,10 +59,11 @@ pip install git+git://github.com/arrayfire/arrayfire-python.git@devel
 cd path/to/arrayfire-python
 python setup.py install
 ```
+Rather than installing and building ArrayFire elsewhere in the system, you can also build directly through python by first setting the `AF_BUILD_LOCAL_LIBS=1` environment variable. Additional setup will be required to build ArrayFire, including satisfying dependencies and further CMake configuration. Details on how to pass additional arguments to the build systems can be found in the [scikit-build documentation.](https://scikit-build.readthedocs.io/en/latest/)
 
 **Post Installation:**
 
-Please follow [these instructions](https://github.com/arrayfire/arrayfire-python/wiki) to ensure the arrayfire-python can find the arrayfire libraries.
+If you are not using one of the pre-built wheels, you may need to ensure arrayfire-python can find the installed arrayfire libraries. Please follow [these instructions](https://github.com/arrayfire/arrayfire-python/wiki) to ensure that arrayfire-python can find the arrayfire libraries.
 
 To run arrayfire tests, you can run the following command from command line.
 

--- a/arrayfire/library.py
+++ b/arrayfire/library.py
@@ -493,7 +493,6 @@ class VARIANCE(_Enum):
 _VER_MAJOR_PLACEHOLDER = "__VER_MAJOR__"
 
 def _setup():
-    import platform
     platform_name = platform.system()
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja", "git"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja", "git"]
+requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ version = 3.8.0
 description = Python bindings for ArrayFire
 licence = BSD
 long_description = file: README.md
+long_description_content_type = text/markdown
 maintainer = ArrayFire
 maintainer_email = technical@arrayfire.com
 url = http://arrayfire.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = arrayfire
-version = 3.7.20200213
+version = 3.8.0
 description = Python bindings for ArrayFire
 licence = BSD
 long_description = file: README.md
@@ -15,6 +15,8 @@ classifiers =
 
 [options]
 packages = find:
+install_requires=
+    scikit-build
 
 [options.packages.find]
 include = arrayfire

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,74 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 ########################################################
 
-# TODO: Look for af libraries during setup
+import os
 
-from setuptools import setup
+# package can be distributed with arrayfire binaries or
+# just with python wrapper files, the AF_BUILD_LOCAL
+# environment var determines whether to build the arrayfire
+# binaries locally rather than searching in a system install
 
-setup()
+AF_BUILD_LOCAL_LIBS = os.environ.get('AF_BUILD_LOCAL_LIBS')
+print(f'AF_BUILD_LOCAL_LIBS={AF_BUILD_LOCAL_LIBS}')
+if AF_BUILD_LOCAL_LIBS:
+    print('Proceeding to build ArrayFire libraries')
+else:
+    print('Skipping binaries installation, only python files will be installed')
+
+AF_BUILD_CPU = os.environ.get('AF_BUILD_CPU')
+AF_BUILD_CPU = 1 if AF_BUILD_CPU is None else int(AF_BUILD_CPU)
+AF_BUILD_CPU_CMAKE_STR = '-DAF_BUILD_CPU:BOOL=ON' if (AF_BUILD_CPU == 1) else '-DAF_BUILD_CPU:BOOL=OFF'
+
+AF_BUILD_CUDA = os.environ.get('AF_BUILD_CUDA')
+AF_BUILD_CUDA = 1 if AF_BUILD_CUDA is None else int(AF_BUILD_CUDA)
+AF_BUILD_CUDA_CMAKE_STR = '-DAF_BUILD_CUDA:BOOL=ON' if (AF_BUILD_CUDA == 1) else '-DAF_BUILD_CUDA:BOOL=OFF'
+
+AF_BUILD_OPENCL = os.environ.get('AF_BUILD_OPENCL')
+AF_BUILD_OPENCL = 1 if AF_BUILD_OPENCL is None else int(AF_BUILD_OPENCL)
+AF_BUILD_OPENCL_CMAKE_STR = '-DAF_BUILD_OPENCL:BOOL=ON' if (AF_BUILD_OPENCL == 1) else '-DAF_BUILD_OPENCL:BOOL=OFF'
+
+AF_BUILD_UNIFIED = os.environ.get('AF_BUILD_UNIFIED')
+AF_BUILD_UNIFIED = 1 if AF_BUILD_UNIFIED is None else int(AF_BUILD_UNIFIED)
+AF_BUILD_UNIFIED_CMAKE_STR = '-DAF_BUILD_UNIFIED:BOOL=ON' if (AF_BUILD_UNIFIED == 1) else '-DAF_BUILD_UNIFIED:BOOL=OFF'
+
+if AF_BUILD_LOCAL_LIBS:
+    # invoke cmake and build arrayfire libraries to install locally in package
+    from skbuild import setup
+
+    def filter_af_files(cmake_manifest):
+        cmake_manifest = list(filter(lambda name: not (name.endswith('.h') 
+            or name.endswith('.cpp')
+            or name.endswith('.hpp')
+            or name.endswith('.cmake')
+            or name.endswith('jpg')
+            or name.endswith('png')
+            or 'examples' in name), cmake_manifest))
+        return cmake_manifest
+
+    print('Building CMAKE with following configurable variables: ')
+    print(AF_BUILD_CPU_CMAKE_STR)
+    print(AF_BUILD_CUDA_CMAKE_STR)
+    print(AF_BUILD_OPENCL_CMAKE_STR)
+    print(AF_BUILD_UNIFIED_CMAKE_STR)
+
+
+    setup(
+        cmake_install_dir='arrayfire',
+        cmake_process_manifest_hook=filter_af_files,
+        cmake_args=[AF_BUILD_CPU_CMAKE_STR,
+                    AF_BUILD_CUDA_CMAKE_STR,
+                    AF_BUILD_OPENCL_CMAKE_STR,
+                    AF_BUILD_UNIFIED_CMAKE_STR,
+                    '-DCUDA_architecture_build_targets:STRING=All' # todo: pass from environ
+                    '-DAF_BUILD_DOCS:BOOL=OFF',
+                    '-DAF_BUILD_EXAMPLES:BOOL=OFF',
+                    '-DAF_INSTALL_STANDALONE:BOOL=ON',
+                    '-DBUILD_TESTING:BOOL=OFF',
+                    ]
+    )
+
+else:
+    # ignores local arrayfire libraries, will search system instead
+    from setuptools import setup
+    setup()
+

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@
 ########################################################
 
 import os
+import re
 
 # package can be distributed with arrayfire binaries or
 # just with python wrapper files, the AF_BUILD_LOCAL
@@ -51,14 +52,17 @@ if AF_BUILD_LOCAL_LIBS:
             or name.endswith('jpg')
             or name.endswith('png')
             or name.endswith('libaf.so') #avoids duplicates due to symlinks
-            or name.endswith('libaf.so.3')
+            or re.match('.*libaf\.so\.3\..*', name) is not None
             or name.endswith('libafcpu.so')
-            or name.endswith('libafcpu.so.3')
+            or re.match('.*libafcpu\.so\.3\..*', name) is not None
             or name.endswith('libafcuda.so')
-            or name.endswith('libafcuda.so.3')
+            or re.match('.*libafcuda\.so\.3\..*', name) is not None
             or name.endswith('libafopencl.so')
-            or name.endswith('libafopencl.so.3')
+            or re.match('.*libafopencl\.so\.3\..*', name) is not None
+            or name.endswith('libforge.so')
+            or re.match('.*libforge\.so\.1\..*', name) is not None
             or 'examples' in name), cmake_manifest))
+        print(cmake_manifest)
         return cmake_manifest
 
     print('Building CMAKE with following configurable variables: ')
@@ -69,16 +73,19 @@ if AF_BUILD_LOCAL_LIBS:
 
 
     setup(
-        cmake_install_dir='arrayfire',
+        packages=['arrayfire'],
+        cmake_install_dir='',
         cmake_process_manifest_hook=filter_af_files,
+        include_package_data=False,
         cmake_args=[AF_BUILD_CPU_CMAKE_STR,
                     AF_BUILD_CUDA_CMAKE_STR,
                     AF_BUILD_OPENCL_CMAKE_STR,
                     AF_BUILD_UNIFIED_CMAKE_STR,
+                    # todo: pass additional args from environ
                     '-DCMAKE_BUILD_TYPE:STRING="RelWithDebInfo"',
-                    '-DFG_USE_STATIC_CPPFLAGS:BOOL=ON',
+                    '-DFG_USE_STATIC_CPPFLAGS:BOOL=OFF',
                     '-DFG_WITH_FREEIMAGE:BOOL=OFF',
-                    '-DCUDA_architecture_build_targets:STRING=All', # todo: pass from environ
+                    '-DCUDA_architecture_build_targets:STRING=All', 
                     '-DAF_BUILD_DOCS:BOOL=OFF',
                     '-DAF_BUILD_EXAMPLES:BOOL=OFF',
                     '-DAF_INSTALL_STANDALONE:BOOL=ON',
@@ -86,6 +93,8 @@ if AF_BUILD_LOCAL_LIBS:
                     '-DAF_WITH_LOGGING:BOOL=ON',
                     '-DBUILD_TESTING:BOOL=OFF',
                     '-DAF_BUILD_FORGE:BOOL=ON',
+                    '-DAF_INSTALL_LIB_DIR:STRING=arrayfire',
+                    '-DFG_INSTALL_LIB_DIR:STRING=arrayfire',
                     ]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ if AF_BUILD_LOCAL_LIBS:
             or name.endswith('libforge.so')
             or re.match('.*libforge\.so\.1\..*', name) is not None
             or 'examples' in name), cmake_manifest))
-        print(cmake_manifest)
         return cmake_manifest
 
     print('Building CMAKE with following configurable variables: ')
@@ -94,7 +93,9 @@ if AF_BUILD_LOCAL_LIBS:
                     '-DBUILD_TESTING:BOOL=OFF',
                     '-DAF_BUILD_FORGE:BOOL=ON',
                     '-DAF_INSTALL_LIB_DIR:STRING=arrayfire',
+                    '-DAF_INSTALL_BIN_DIR:STRING=arrayfire',
                     '-DFG_INSTALL_LIB_DIR:STRING=arrayfire',
+                    '-DAF_WITH_STATIC_MKL=ON',
                     ]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,14 @@ if AF_BUILD_LOCAL_LIBS:
             or name.endswith('.cmake')
             or name.endswith('jpg')
             or name.endswith('png')
+            or name.endswith('libaf.so') #avoids duplicates due to symlinks
+            or name.endswith('libaf.so.3')
+            or name.endswith('libafcpu.so')
+            or name.endswith('libafcpu.so.3')
+            or name.endswith('libafcuda.so')
+            or name.endswith('libafcuda.so.3')
+            or name.endswith('libafopencl.so')
+            or name.endswith('libafopencl.so.3')
             or 'examples' in name), cmake_manifest))
         return cmake_manifest
 
@@ -67,11 +75,17 @@ if AF_BUILD_LOCAL_LIBS:
                     AF_BUILD_CUDA_CMAKE_STR,
                     AF_BUILD_OPENCL_CMAKE_STR,
                     AF_BUILD_UNIFIED_CMAKE_STR,
-                    '-DCUDA_architecture_build_targets:STRING=All' # todo: pass from environ
+                    '-DCMAKE_BUILD_TYPE:STRING="RelWithDebInfo"',
+                    '-DFG_USE_STATIC_CPPFLAGS:BOOL=ON',
+                    '-DFG_WITH_FREEIMAGE:BOOL=OFF',
+                    '-DCUDA_architecture_build_targets:STRING=All', # todo: pass from environ
                     '-DAF_BUILD_DOCS:BOOL=OFF',
                     '-DAF_BUILD_EXAMPLES:BOOL=OFF',
                     '-DAF_INSTALL_STANDALONE:BOOL=ON',
+                    '-DAF_WITH_IMAGEIO:BOOL=ON',
+                    '-DAF_WITH_LOGGING:BOOL=ON',
                     '-DBUILD_TESTING:BOOL=OFF',
+                    '-DAF_BUILD_FORGE:BOOL=ON',
                     ]
     )
 


### PR DESCRIPTION
uses skbuild to optionally build the arrayfire library during python setup.py build/install
AF_BUILD_LOCAL_LIBS=1 environment variable used to perform the build. if it is not specified, setup.py will just install the .py files skipping the binary build step. The library has also been tweaked to prefer to load from the new local arrayfire/lib directory. If it doesn't exist the default system paths will be searched as in previous releases